### PR TITLE
Crash on cancel load fix 

### DIFF
--- a/box-tool/src/main/java/smashdudes/core/boxtool/presentation/UI.java
+++ b/box-tool/src/main/java/smashdudes/core/boxtool/presentation/UI.java
@@ -135,8 +135,11 @@ public class UI
                 if(ImGui.menuItem("Load..."))
                 {
                     String filepath = Utils.chooseFileToLoad("json");
-                    character = VM.mapping(service.readCharacter(filepath));
-                    commandList.clear();
+                    if(filepath != null)
+                    {
+                        character = VM.mapping(service.readCharacter(filepath));
+                        commandList.clear();
+                    }
                 }
 
                 ImGui.endMenu();


### PR DESCRIPTION
- Check to see if we selected a file or not before we attempt to load a character