### PR TITLE
Debug Box Flickering Fix

### DIFF
--- a/core/src/main/java/smashdudes/ecs/Engine.java
+++ b/core/src/main/java/smashdudes/ecs/Engine.java
@@ -49,6 +49,7 @@ public class Engine
         PlayerControllerSystem ctrlSys = new PlayerControllerSystem(this);
         ctrlSys.setEnabled(false);
 
+        gameSystems.add(new DebugResetSystem(this));
         gameSystems.add(new PreviousPositionSystem(this));
         gameSystems.add(new CountdownSystem(this));
         gameSystems.add(new PlayerStateSystem(this));

--- a/core/src/main/java/smashdudes/ecs/components/DebugDrawComponent.java
+++ b/core/src/main/java/smashdudes/ecs/components/DebugDrawComponent.java
@@ -2,9 +2,7 @@ package smashdudes.ecs.components;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
-import com.badlogic.gdx.math.Circle;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
 import smashdudes.ecs.Component;
@@ -13,8 +11,8 @@ public class DebugDrawComponent extends Component
 {
     public class DebugRect
     {
-        private Color color;
-        private Rectangle rect;
+        private final Color color;
+        private final Rectangle rect;
 
         public DebugRect(Color color, Rectangle rect)
         {
@@ -26,7 +24,7 @@ public class DebugDrawComponent extends Component
         public Rectangle getRect() { return rect; }
     }
 
-    private ArrayMap<ShapeRenderer.ShapeType, Array<DebugRect>> rectangles = new ArrayMap<>();
+    private final ArrayMap<ShapeRenderer.ShapeType, Array<DebugRect>> rectangles = new ArrayMap<>();
 
     public DebugDrawComponent()
     {

--- a/core/src/main/java/smashdudes/ecs/systems/DebugResetSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/DebugResetSystem.java
@@ -1,0 +1,21 @@
+package smashdudes.ecs.systems;
+
+import smashdudes.ecs.Engine;
+import smashdudes.ecs.Entity;
+import smashdudes.ecs.components.DebugDrawComponent;
+
+public class DebugResetSystem extends GameSystem
+{
+    public DebugResetSystem(Engine engine)
+    {
+        super(engine);
+
+        registerComponentType(DebugDrawComponent.class);
+    }
+
+    @Override
+    protected void updateEntity(Entity entity, float dt)
+    {
+        entity.getComponent(DebugDrawComponent.class).reset();
+    }
+}

--- a/core/src/main/java/smashdudes/ecs/systems/RenderDebugSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/RenderDebugSystem.java
@@ -1,6 +1,5 @@
 package smashdudes.ecs.systems;
 
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.math.Rectangle;
@@ -66,7 +65,5 @@ public class RenderDebugSystem extends RenderSystem
 
             sh.end();
         }
-
-        d.reset();
     }
 }


### PR DESCRIPTION
## Description 

When we introduced game systems and render systems running at different rates,  an issue was introduced  where debug boxes would flicker. 

This was due to debug boxes being "immediate" meaning they are pushed every frame and cleared at the end. 
We would "push" boxes in the update loop but "reset" in the render loop, meaning there was a disconnect between them on frames when the gameSystems did not run. 

The solution is to simply put the debug resetting in the game update systems. 

## Changes 
- Removed debug box reset in render loop
- Added debug box reset to update loop