### PR TITLE
Player state fixups

### DIFF
--- a/core/src/main/java/smashdudes/ecs/systems/StateSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/StateSystem.java
@@ -25,12 +25,6 @@ public class StateSystem extends GameSystem
     {
         StateComponent s = entity.getComponent(StateComponent.class);
         s.state.update(dt);
-        Event event = s.state.popEvent();
-        while (event != null)
-        {
-            engine.addEvent(event);
-            event = s.state.popEvent();
-        }
         s.setNextState(s.state.getNextState());
     }
 

--- a/core/src/main/java/smashdudes/gameplay/state/State.java
+++ b/core/src/main/java/smashdudes/gameplay/state/State.java
@@ -1,18 +1,26 @@
 package smashdudes.gameplay.state;
 
-import com.badlogic.gdx.utils.Queue;
 import smashdudes.ecs.Entity;
 import smashdudes.ecs.events.Event;
 
 public abstract class State
 {
+    public interface FireEvent
+    {
+        void execute(Event event);
+    }
+    protected static FireEvent fireEvent;
+
     protected final Entity entity;
     private boolean onFirstRun = true;
-    private final Queue<Event> eventQueue = new Queue<>();
-
     public State(Entity entity)
     {
         this.entity = entity;
+    }
+
+    public static final void setFireEventCallback(FireEvent fire)
+    {
+        fireEvent = fire;
     }
 
     public final void update(float dt)
@@ -34,23 +42,6 @@ public abstract class State
     public State getNextState()
     {
         return this;
-    }
-
-    protected final void throwEvent(Event event)
-    {
-        eventQueue.addLast(event);
-    }
-
-    public final Event popEvent()
-    {
-        if(eventQueue.notEmpty())
-        {
-            return eventQueue.removeFirst();
-        }
-        else
-        {
-            return null;
-        }
     }
 
     public State handleEvent(Event event)

--- a/core/src/main/java/smashdudes/gameplay/state/playerstate/air/JumpState.java
+++ b/core/src/main/java/smashdudes/gameplay/state/playerstate/air/JumpState.java
@@ -3,6 +3,7 @@ package smashdudes.gameplay.state.playerstate.air;
 import smashdudes.ecs.Entity;
 import smashdudes.ecs.components.CharacterInputComponent;
 import smashdudes.ecs.components.VelocityComponent;
+import smashdudes.ecs.events.JumpEvent;
 import smashdudes.gameplay.state.State;
 
 public class JumpState extends PlayerAirState
@@ -10,6 +11,13 @@ public class JumpState extends PlayerAirState
     public JumpState(Entity entity)
     {
         super(entity);
+    }
+
+    @Override
+    public void onEnter(float dt)
+    {
+        super.onEnter(dt);
+        fireEvent.execute(new JumpEvent(entity));
     }
 
     @Override

--- a/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundIdleState.java
+++ b/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundIdleState.java
@@ -5,6 +5,8 @@ import smashdudes.ecs.components.CharacterInputComponent;
 import smashdudes.ecs.components.JumpComponent;
 import smashdudes.ecs.components.VelocityComponent;
 import smashdudes.gameplay.state.State;
+import smashdudes.gameplay.state.playerstate.air.FallingState;
+import smashdudes.gameplay.state.playerstate.air.JumpState;
 
 public class GroundIdleState extends PlayerGroundState
 {

--- a/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundIdleState.java
+++ b/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundIdleState.java
@@ -4,10 +4,7 @@ import smashdudes.ecs.Entity;
 import smashdudes.ecs.components.CharacterInputComponent;
 import smashdudes.ecs.components.JumpComponent;
 import smashdudes.ecs.components.VelocityComponent;
-import smashdudes.ecs.events.JumpEvent;
 import smashdudes.gameplay.state.State;
-import smashdudes.gameplay.state.playerstate.air.FallingState;
-import smashdudes.gameplay.state.playerstate.air.JumpState;
 
 public class GroundIdleState extends PlayerGroundState
 {
@@ -38,15 +35,13 @@ public class GroundIdleState extends PlayerGroundState
         {
             return new GroundAttackState(entity);
         }
-        else if( !(i.currentState.left && i.currentState.right) &&
-                (i.currentState.left || i.currentState.right) )
+        else if( !(i.currentState.left && i.currentState.right) && (i.currentState.left || i.currentState.right) )
         {
             return new GroundRunningState(entity);
         }
         else if(i.currentState.up)
         {
             v.velocity.y = j.jumpStrength;
-            throwEvent(new JumpEvent(entity));
             return new JumpState(entity);
         }
         else if(v.velocity.y < 0)

--- a/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundRunningState.java
+++ b/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundRunningState.java
@@ -1,12 +1,12 @@
 package smashdudes.gameplay.state.playerstate.ground;
 
-import com.badlogic.gdx.math.MathUtils;
 import smashdudes.ecs.Entity;
-import smashdudes.ecs.components.AnimationContainerComponent;
 import smashdudes.ecs.components.CharacterInputComponent;
 import smashdudes.ecs.components.JumpComponent;
 import smashdudes.ecs.components.VelocityComponent;
 import smashdudes.gameplay.state.State;
+import smashdudes.gameplay.state.playerstate.air.FallingState;
+import smashdudes.gameplay.state.playerstate.air.JumpState;
 
 public class GroundRunningState extends PlayerGroundState
 {

--- a/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundRunningState.java
+++ b/core/src/main/java/smashdudes/gameplay/state/playerstate/ground/GroundRunningState.java
@@ -1,12 +1,12 @@
 package smashdudes.gameplay.state.playerstate.ground;
 
+import com.badlogic.gdx.math.MathUtils;
 import smashdudes.ecs.Entity;
+import smashdudes.ecs.components.AnimationContainerComponent;
 import smashdudes.ecs.components.CharacterInputComponent;
 import smashdudes.ecs.components.JumpComponent;
 import smashdudes.ecs.components.VelocityComponent;
-import smashdudes.ecs.events.JumpEvent;
 import smashdudes.gameplay.state.State;
-import smashdudes.gameplay.state.playerstate.air.JumpState;
 
 public class GroundRunningState extends PlayerGroundState
 {
@@ -49,33 +49,24 @@ public class GroundRunningState extends PlayerGroundState
         CharacterInputComponent ci = entity.getComponent(CharacterInputComponent.class);
         VelocityComponent v  = entity.getComponent(VelocityComponent.class);
 
-        if(ci.currentState.punch)
+        if (v.velocity.y < 0)
+        {
+            return new FallingState(entity);
+        }
+        else if(ci.currentState.punch)
         {
             return new GroundAttackState(entity);
         }
         else if(ci.currentState.up && v.velocity.y == 0)
         {
             v.velocity.y = j.jumpStrength;
-            throwEvent(new JumpEvent(entity));
             return new JumpState(entity);
         }
-        else if( (ci.currentState.left && ci.currentState.right) ||
-                !(ci.currentState.left || ci.currentState.right) ||
-                  Math.abs(v.velocity.y) > 0)
+        else if(Math.abs(v.velocity.x) < 0.01)
         {
-            if(Math.abs(v.velocity.y) > 0)
-            {
-                return new JumpState(entity);
-            }
-            else
-            {
-                return new GroundIdleState(entity);
-            }
+            return new GroundIdleState(entity);
         }
-        else if (v.velocity.y < 0)
-        {
-            return new JumpState(entity);
-        }
+
 
         return this;
     }

--- a/core/src/main/java/smashdudes/screens/GameplayScreen.java
+++ b/core/src/main/java/smashdudes/screens/GameplayScreen.java
@@ -205,6 +205,7 @@ public class GameplayScreen extends GameScreen
         animContainer.setDefault(GroundIdleState.class);
         player.addComponent(animContainer);
 
+        State.setFireEventCallback(event -> ecsEngine.addEvent(event));
         StateComponent s = new StateComponent(new FallingState(player));
         player.addComponent(s);
 


### PR DESCRIPTION
## Description 
Events for the State class were fundamentally flawed. The state system already queued events and forwarded them to the state. 
This effectively added a frame of latency to the events being used by the state system as they would not process until the following frames call to `update`. 

Along with that, events that were "thrown" within the state system were not connected to the rest of the ECS, only internal to the state class. This has been changed as well. 

This all came about because I noticed the jump sound effect no longer played, as the audio system was not receiving jump events.

NOTE: This PR should go in after https://github.com/goldDaniel/smash-dudes/pull/70 gets merged, as this will require conflict resolution. I will take care of it.

## Changes 
- Events fired within a State now can reach the rest of the ECS 
- Removed event queue which added a frame of delay to events 
- Simplified `GroundRunningState` logic 
- Fixed `GroundRunningState` logic to not enter `JumpState` when falling 
