### PR TITLE
Separate responsibility of camera and viewport from individual systems

### DIFF
--- a/core/src/main/java/smashdudes/ecs/Engine.java
+++ b/core/src/main/java/smashdudes/ecs/Engine.java
@@ -1,6 +1,5 @@
 package smashdudes.ecs;
 
-import com.badlogic.gdx.Game;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Queue;
@@ -11,7 +10,6 @@ import smashdudes.ecs.components.StateComponent;
 import smashdudes.ecs.events.Event;
 import smashdudes.ecs.events.StateEvent;
 import smashdudes.ecs.systems.*;
-import smashdudes.gameplay.state.State;
 import smashdudes.graphics.RenderResources;
 
 public class Engine
@@ -41,15 +39,12 @@ public class Engine
 
         ExtendViewport viewport = new ExtendViewport(worldWidth,worldHeight, camera);
 
-        RenderDrawSystem rs = new RenderDrawSystem(this, RenderResources.getSpriteBatch());
-        RenderDebugSystem drs = new RenderDebugSystem(this, RenderResources.getShapeRenderer());
-        UIRenderSystem urs = new UIRenderSystem(this, RenderResources.getSpriteBatch(), RenderResources.getFont("KeepOnTruckin", 24));
+        RenderDrawSystem rs = new RenderDrawSystem(this, camera, viewport);
+        RenderDebugSystem drs = new RenderDebugSystem(this, camera, viewport);
 
-        rs.setCamera(camera);
-        drs.setCamera(camera);
-
-        rs.setViewport(viewport);
-        drs.setViewport(viewport);
+        ExtendViewport uiVP = new ExtendViewport(1280, 720);
+        uiVP.update(1280, 720);
+        UIRenderSystem urs = new UIRenderSystem(this, uiVP.getCamera(), uiVP, RenderResources.getFont("KeepOnTruckin", 24));
 
         PlayerControllerSystem ctrlSys = new PlayerControllerSystem(this);
         ctrlSys.setEnabled(false);
@@ -58,7 +53,7 @@ public class Engine
         gameSystems.add(new PreviousPositionSystem(this));
         gameSystems.add(new CountdownSystem(this));
         gameSystems.add(new StateSystem(this));
-        gameSystems.add(new RenderDirectionSystem(this));
+        gameSystems.add(new DirectionSystem(this));
         gameSystems.add(ctrlSys);
         gameSystems.add(new AIControllerSystem(this));
         gameSystems.add(new GravitySystem(this));

--- a/core/src/main/java/smashdudes/ecs/systems/DirectionSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/DirectionSystem.java
@@ -4,9 +4,9 @@ import smashdudes.ecs.Engine;
 import smashdudes.ecs.Entity;
 import smashdudes.ecs.components.*;
 
-public class RenderDirectionSystem extends GameSystem
+public class DirectionSystem extends GameSystem
 {
-    public RenderDirectionSystem(Engine engine)
+    public DirectionSystem(Engine engine)
     {
         super(engine);
 

--- a/core/src/main/java/smashdudes/ecs/systems/DrawSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/DrawSystem.java
@@ -1,0 +1,38 @@
+package smashdudes.ecs.systems;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.viewport.Viewport;
+import smashdudes.ecs.Engine;
+import smashdudes.graphics.RenderResources;
+
+public class DrawSystem extends RenderSystem
+{
+    protected final Camera camera;
+    protected final Viewport viewport;
+
+    protected final SpriteBatch sb = RenderResources.getSpriteBatch();
+    protected final ShapeRenderer sh = RenderResources.getShapeRenderer();
+
+    public DrawSystem(Engine engine, Camera camera, Viewport viewport)
+    {
+        super(engine);
+        this.camera = camera;
+        this.viewport = viewport;
+    }
+
+    @Override
+    protected void preRender()
+    {
+        sb.setProjectionMatrix(camera.combined);
+        sh.setProjectionMatrix(camera.combined);
+    }
+
+    @Override
+    public void resize(int w, int h)
+    {
+        viewport.update(w, h);
+        viewport.apply();
+    }
+}

--- a/core/src/main/java/smashdudes/ecs/systems/RenderDebugSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/RenderDebugSystem.java
@@ -1,6 +1,7 @@
 package smashdudes.ecs.systems;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -10,42 +11,13 @@ import smashdudes.ecs.Engine;
 import smashdudes.ecs.Entity;
 import smashdudes.ecs.components.DebugDrawComponent;
 
-public class RenderDebugSystem extends RenderSystem
+public class RenderDebugSystem extends DrawSystem
 {
-
-    private OrthographicCamera camera;
-    private Viewport viewport;
-
-    private final ShapeRenderer sh;
-
-    public RenderDebugSystem(Engine engine, ShapeRenderer sh)
+    public RenderDebugSystem(Engine engine, Camera camera, Viewport viewport)
     {
-        super(engine);
-        this.sh = sh;
+        super(engine, camera, viewport);
 
         registerComponentType(DebugDrawComponent.class);
-    }
-
-    public void setCamera(OrthographicCamera camera)
-    {
-        this.camera = camera;
-    }
-
-    public void setViewport(Viewport viewport)
-    {
-        this.viewport = viewport;
-    }
-
-    public void resize(int w, int h)
-    {
-        viewport.update(w, h);
-        viewport.apply();
-    }
-
-    @Override
-    public void preRender()
-    {
-        sh.setProjectionMatrix(camera.combined);
     }
 
     @Override

--- a/core/src/main/java/smashdudes/ecs/systems/RenderDrawSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/RenderDrawSystem.java
@@ -1,5 +1,6 @@
 package smashdudes.ecs.systems;
 
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
@@ -17,7 +18,7 @@ import smashdudes.graphics.RenderResources;
 
 import java.util.Comparator;
 
-public class RenderDrawSystem extends RenderSystem
+public class RenderDrawSystem extends DrawSystem
 {
     private class Renderable
     {
@@ -37,12 +38,9 @@ public class RenderDrawSystem extends RenderSystem
     private OrthographicCamera camera;
     private Viewport viewport;
 
-    private final SpriteBatch sb;
-
-    public RenderDrawSystem(Engine engine, SpriteBatch sb)
+    public RenderDrawSystem(Engine engine, Camera camera, Viewport viewport)
     {
-        super(engine);
-        this.sb = sb;
+        super(engine, camera, viewport);
 
         shaders.put(RenderPass.Default, null); //null will make the spritebatch use its default shader
         shaders.put(RenderPass.Stunned, RenderResources.getShader("shaders/spritebatch.default.vert.glsl", "shaders/spritebatch.stunned.frag.glsl"));
@@ -50,29 +48,6 @@ public class RenderDrawSystem extends RenderSystem
 
         registerComponentType(PositionComponent.class);
         registerComponentType(DrawComponent.class);
-    }
-
-    public void setCamera(OrthographicCamera camera)
-    {
-        this.camera = camera;
-    }
-
-    public void setViewport(Viewport viewport)
-    {
-        this.viewport = viewport;
-    }
-
-    public void resize(int w, int h)
-    {
-        viewport.update(w, h);
-        viewport.apply();
-    }
-
-    @Override
-    public void preRender()
-    {
-        renderables.clear();
-        sb.setProjectionMatrix(camera.combined);
     }
 
     @Override
@@ -134,5 +109,6 @@ public class RenderDrawSystem extends RenderSystem
         }
 
         if(sb.isDrawing()) sb.end();
+        renderables.clear();
     }
 }

--- a/core/src/main/java/smashdudes/ecs/systems/RenderSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/RenderSystem.java
@@ -1,7 +1,13 @@
 package smashdudes.ecs.systems;
 
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.viewport.Viewport;
 import smashdudes.ecs.Engine;
 import smashdudes.ecs.Entity;
+import smashdudes.graphics.RenderResources;
 
 public abstract class RenderSystem extends ISystem
 {

--- a/core/src/main/java/smashdudes/ecs/systems/UIRenderSystem.java
+++ b/core/src/main/java/smashdudes/ecs/systems/UIRenderSystem.java
@@ -1,5 +1,6 @@
 package smashdudes.ecs.systems;
 
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -19,7 +20,7 @@ import smashdudes.ecs.events.Event;
 import smashdudes.ecs.events.WinEvent;
 import smashdudes.graphics.RenderResources;
 
-public class UIRenderSystem extends RenderSystem
+public class UIRenderSystem extends DrawSystem
 {
     private class CharacterDisplay implements Comparable
     {
@@ -50,15 +51,10 @@ public class UIRenderSystem extends RenderSystem
         }
     }
 
-    private final OrthographicCamera camera;
-    private final Viewport viewport;
-
     private final float worldWidth;
     private final float worldHeight;
 
     private final GlyphLayout layout;
-
-    private final SpriteBatch sb;
     private final BitmapFont font;
 
     private final Array<CharacterDisplay> players = new Array<>();
@@ -68,20 +64,16 @@ public class UIRenderSystem extends RenderSystem
     private String countDisplay = " ";
     private float displayTimer;
 
-    public UIRenderSystem(Engine engine, SpriteBatch sb, BitmapFont font)
+    public UIRenderSystem(Engine engine, Camera camera, Viewport viewport, BitmapFont font)
     {
-        super(engine);
-        this.sb = sb;
+        super(engine, camera, viewport);
         this.font = font;
 
-        worldWidth = 1280;
-        worldHeight = 720;
+        worldWidth = viewport.getWorldWidth();
+        worldHeight = viewport.getWorldHeight();
         layout = new GlyphLayout(font, "");
 
         displayTimer = 0;
-
-        this.viewport = new ExtendViewport(worldWidth, worldHeight);
-        this.camera = (OrthographicCamera)viewport.getCamera();
 
         registerComponentType(PlayerComponent.class);
         registerComponentType(HealthComponent.class);
@@ -89,18 +81,6 @@ public class UIRenderSystem extends RenderSystem
 
         registerEventType(CountdownEvent.class);
         registerEventType(WinEvent.class);
-    }
-
-    public void resize(int w, int h)
-    {
-        viewport.update(w, h);
-        viewport.apply();
-    }
-
-    @Override
-    public void preRender()
-    {
-        sb.setProjectionMatrix(camera.combined);
     }
 
     @Override


### PR DESCRIPTION
## Description
Separates the render systems responsible for drawing, and those that are simply responsible for things related to rendering

## Changes
- Added a `DrawSystem` class, which all systems that actually render/blit should extend.