### PR TITLE
emitter cleanup / limited lifetime emitters

### DIFF
--- a/box-tool/src/main/java/smashdudes/particletool/logic/ParticleEditorContext.java
+++ b/box-tool/src/main/java/smashdudes/particletool/logic/ParticleEditorContext.java
@@ -1,6 +1,7 @@
 package smashdudes.particletool.logic;
 
 import com.badlogic.gdx.utils.ArrayMap;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.Pool;
 import smashdudes.content.DTO;
 import smashdudes.core.logic.commands.Command;
@@ -8,6 +9,8 @@ import smashdudes.core.logic.commands.CommandList;
 import smashdudes.graphics.effects.Particle;
 import smashdudes.graphics.effects.ParticleEmitter;
 import smashdudes.graphics.effects.ParticleEmitterConfig;
+
+import java.util.Arrays;
 
 public class ParticleEditorContext
 {
@@ -127,5 +130,26 @@ public class ParticleEditorContext
     public void execute(Command c)
     {
         cl.execute(c);
+    }
+
+    public boolean isFinished()
+    {
+        for(ParticleEmitter emitter : emitters.values().toArray())
+        {
+            if(!emitter.depleted())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void reset()
+    {
+        for(ParticleEmitter emitter : emitters.values().toArray())
+        {
+            emitter.reset();
+        }
     }
 }

--- a/box-tool/src/main/java/smashdudes/particletool/logic/ParticleEditorContext.java
+++ b/box-tool/src/main/java/smashdudes/particletool/logic/ParticleEditorContext.java
@@ -32,6 +32,7 @@ public class ParticleEditorContext
     };
 
     private boolean playing = false;
+    private boolean started = false;
 
 
     public ParticleEditorContext(CommandList cl, DTO.EffectDescription effect)
@@ -115,6 +116,7 @@ public class ParticleEditorContext
     public void play()
     {
         playing = true;
+        started = true;
     }
 
     public void stop()
@@ -143,6 +145,11 @@ public class ParticleEditorContext
         }
 
         return true;
+    }
+
+    public boolean hasStarted()
+    {
+        return started;
     }
 
     public void reset()

--- a/box-tool/src/main/java/smashdudes/particletool/presentation/EmitterEditorWidget.java
+++ b/box-tool/src/main/java/smashdudes/particletool/presentation/EmitterEditorWidget.java
@@ -27,6 +27,10 @@ public class EmitterEditorWidget extends ImGuiWidget
         if(ImGui.button("Play"))
         {
             context.play();
+            if(context.isFinished())
+            {
+                context.reset();
+            }
         }
         ImGui.sameLine();
         if(ImGui.button("Pause"))
@@ -69,6 +73,13 @@ public class EmitterEditorWidget extends ImGuiWidget
         {
             if(emissionRate.get() < 0) emissionRate.set(0);
             context.execute(new PropertyEditCommand<>("emissionRate", emissionRate.get(), config));
+        }
+
+        ImFloat emissionDuration = new ImFloat(config.emissionDuration);
+        if(ImGui.inputFloat("Emission Duration", emissionDuration, 0.1f, 10))
+        {
+            if(emissionDuration.get() < 0) emissionDuration.set(0);
+            context.execute(new PropertyEditCommand<>("emissionDuration", emissionDuration.get(), config));
         }
 
         ImGui.sameLine();

--- a/box-tool/src/main/java/smashdudes/particletool/presentation/EmitterEditorWidget.java
+++ b/box-tool/src/main/java/smashdudes/particletool/presentation/EmitterEditorWidget.java
@@ -24,12 +24,17 @@ public class EmitterEditorWidget extends ImGuiWidget
     @Override
     protected void draw(ShapeRenderer sh, SpriteBatch sb)
     {
-        if(ImGui.button("Play"))
+        String playText = context.isFinished() ? "Reset" : "Play";
+        playText = !context.isPlaying() && !context.isFinished() && context.hasStarted() ? "Resume" : playText;
+        if(ImGui.button(playText))
         {
-            context.play();
             if(context.isFinished())
             {
                 context.reset();
+            }
+            else
+            {
+                context.play();
             }
         }
         ImGui.sameLine();

--- a/core/src/main/java/smashdudes/graphics/effects/Particle.java
+++ b/core/src/main/java/smashdudes/graphics/effects/Particle.java
@@ -42,19 +42,4 @@ public class Particle
     public float gEnd;
     public float bEnd;
     public float aEnd;
-
-    public void render(SpriteBatch sb)
-    {
-        float t = 1.0f  - life / initialLife;
-
-        float scale = MathUtils.lerp(scaleStart, scaleEnd, t);
-
-        float r = MathUtils.lerp(rStart, rEnd, t);
-        float g = MathUtils.lerp(gStart, gEnd, t);
-        float b = MathUtils.lerp(bStart, bEnd, t);
-        float a = MathUtils.lerp(aStart, aEnd, t);
-
-        sb.setColor(r, g, b, a);
-        sb.draw(RenderResources.getTexture("textures/particleTexture.png"), x - scale / 2, y - scale / 2, scale, scale);
-    }
 }

--- a/core/src/main/java/smashdudes/graphics/effects/Particle.java
+++ b/core/src/main/java/smashdudes/graphics/effects/Particle.java
@@ -1,5 +1,9 @@
 package smashdudes.graphics.effects;
 
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.MathUtils;
+import smashdudes.graphics.RenderResources;
+
 public class Particle
 {
 
@@ -38,4 +42,19 @@ public class Particle
     public float gEnd;
     public float bEnd;
     public float aEnd;
+
+    public void render(SpriteBatch sb)
+    {
+        float t = 1.0f  - life / initialLife;
+
+        float scale = MathUtils.lerp(scaleStart, scaleEnd, t);
+
+        float r = MathUtils.lerp(rStart, rEnd, t);
+        float g = MathUtils.lerp(gStart, gEnd, t);
+        float b = MathUtils.lerp(bStart, bEnd, t);
+        float a = MathUtils.lerp(aStart, aEnd, t);
+
+        sb.setColor(r, g, b, a);
+        sb.draw(RenderResources.getTexture("textures/particleTexture.png"), x - scale / 2, y - scale / 2, scale, scale);
+    }
 }

--- a/core/src/main/java/smashdudes/graphics/effects/ParticleEmitterConfig.java
+++ b/core/src/main/java/smashdudes/graphics/effects/ParticleEmitterConfig.java
@@ -6,6 +6,8 @@ import com.badlogic.gdx.math.Vector2;
 
 public class ParticleEmitterConfig
 {
+    public static final float ENDLESS = -1;
+
     public String name = "";
 
     public Vector2 origin = new Vector2();

--- a/core/src/main/java/smashdudes/graphics/effects/ParticleEmitterConfig.java
+++ b/core/src/main/java/smashdudes/graphics/effects/ParticleEmitterConfig.java
@@ -12,6 +12,7 @@ public class ParticleEmitterConfig
 
     // Emission
     public float emissionRate = 1000;
+    public float emissionDuration = 1;
     public ParticleEmitterShape spawnShape = ParticleEmitterShape.Point;
     public float spawnShapeScale = 1.0f;
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace]
 Pos=0,0
-Size=2560,1377
+Size=3840,2066
 Collapsed=0
 
 [Window][Debug##Default]
@@ -19,8 +19,8 @@ Size=800,120
 Collapsed=0
 
 [Window][Emitter Editor]
-Pos=1245,41
-Size=1303,1323
+Pos=2525,41
+Size=1303,2012
 Collapsed=0
 DockId=0x00000002,0
 
@@ -30,8 +30,22 @@ Size=1231,1323
 Collapsed=0
 DockId=0x00000001,0
 
+[Window][Effect View]
+Pos=12,41
+Size=1679,2012
+Collapsed=0
+DockId=0x00000003,0
+
+[Window][Effect Editor]
+Pos=12,41
+Size=1679,2012
+Collapsed=0
+DockId=0x00000003,1
+
 [Docking][Data]
-DockSpace   ID=0x3FC20BEE Window=0x9A404470 Pos=12,41 Size=2536,1323 Split=X
-  DockNode  ID=0x00000001 Parent=0x3FC20BEE SizeRef=1231,2012 CentralNode=1 Selected=0xC1DCC499
-  DockNode  ID=0x00000002 Parent=0x3FC20BEE SizeRef=1303,2012 Selected=0x147F36C4
+DockSpace     ID=0x3FC20BEE Window=0x9A404470 Pos=12,41 Size=3816,2012 Split=X
+  DockNode    ID=0x00000003 Parent=0x3FC20BEE SizeRef=1679,2012 Selected=0x33B4CB80
+  DockNode    ID=0x00000004 Parent=0x3FC20BEE SizeRef=2135,2012 Split=X
+    DockNode  ID=0x00000001 Parent=0x00000004 SizeRef=830,2012 CentralNode=1 Selected=0xC1DCC499
+    DockNode  ID=0x00000002 Parent=0x00000004 SizeRef=1303,2012 Selected=0x147F36C4
 


### PR DESCRIPTION
## Description
More OO-like separation of responsibilities with `Particle` and `ParticleEmitter`. As well as limited life time emitters.

## Changes
- Added a UI element when editing emitters for `emissionDuration`

## Notes
- When a particle emitter is finished 'emitting', pressing play will restart the effect with identical initial conditions. 
- Could add seeding to replay identical effects?